### PR TITLE
feat: expand mode and the prompt container

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2,6 +2,7 @@
   "default_text_tips": "Powered by OpenAI and Vercel\n- Chat with us now. Press `Enter` to send and `Shift`+`Enter` to add a new line. \n- Input `/` or click the button at the bottom left to add a preset prompt",
   "default_image_tips": "Powered by OpenAI, Replicate and Vercel\n- Chat with us now. Press `Enter` to send and `Shift`+`Enter` to add a new line. \n- The image generation does not support continuous dialogue. Please input directly the desired image effect, for example: `a cat`.\n- For model `DALL-E`, expend `OpenAI` tokens. The effective access time for the image link is `2` hours. Please make sure to save it in time if necessary.\n- For model `Midjourney`, depending on the `Discord` configurations, image generation may take a while, with a default timeout of `5` minutes. Please be patient and wait.\n- For model `Replicate`, there are certain free allowances, but they are only available for local and custom deployments. It is recommended to add the prefix `mdjrny-v4 style`",
   "chat_placeholder": "Start a conversation",
+  "chat_expanded_placeholder": "Press `Enter` to add a new line and `Shirt` + `Enter` to send",
   "empty_conversation": "Please select a conversation",
   "search_placeholder": "Search",
   "action_clear": "Clear all conversations",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -2,6 +2,7 @@
   "default_text_tips": "由 OpenAI 和 Vercel 提供支持\n- 点击下方发起聊天，`Enter`键发送，`Shift`+`Enter`键换行\n- 输入`/`或者点击左下角按钮添加预设提示",
   "default_image_tips": "由 OpenAI、Replicate 和 Vercel 提供支持\n- 点击下方发起聊天，`Enter`键发送，`Shift`+`Enter`键换行\n- 图片生成不支持连续对话，直接输入你想要的图片效果，例如：`一只猫`\n- 对于 `DALL-E` 模型，消耗 `OpenAI` token，图片链接的有效访问时间为 `2` 小时，如有需要请及时保存\n- 对于 `Midjourney` 模型，依赖 `Discord` 相关配置，图片生成时间一般较长，默认超时时间为 `5` 分钟，请耐心等待\n- 对于 `Replicate` 模型，有一定免费次数但仅本地和自定义部署时可用，推荐使用英文且加上前缀 `mdjrny-v4 style`",
   "chat_placeholder": "开始聊天",
+  "chat_expanded_placeholder": "`Enter` 换行, `Shirt` + `Enter` 发送",
   "empty_conversation": "请点击左侧对话",
   "search_placeholder": "搜索",
   "action_clear": "清空所有会话",

--- a/src/components/PromptSelect/index.tsx
+++ b/src/components/PromptSelect/index.tsx
@@ -67,7 +67,7 @@ const PromptSelect: FC<{
       menu={{ items }}
       placement="topLeft"
       open={items.length > 0 && showPrompt}
-      getPopupContainer={(node) => node}
+      getPopupContainer={(node) => node.parentElement}
       autoAdjustOverflow={false}
     >
       {children}

--- a/src/modules/Content/MessageInput.tsx
+++ b/src/modules/Content/MessageInput.tsx
@@ -32,7 +32,7 @@ const MessageInput: FC<{
   const { i18n, currentId } = useContext(GlobalContext);
   const [promptKeyword, setPromptKeyword] = useState('');
   const [isInputComposition, setIsInputComposition] = useState(false);
-
+  const [isExpanded, setIsExpanded] = useState(false);
   // textarea ref
   const ref = useRef(null);
 
@@ -66,7 +66,7 @@ const MessageInput: FC<{
   }, [currentId]);
 
   return (
-    <div className="flex items-center p-5 pt-5">
+    <div className="flex items-start p-5 pt-5">
       <PromptSelect
         keyword={promptKeyword}
         showPrompt={showPrompt}
@@ -75,7 +75,11 @@ const MessageInput: FC<{
         <div className="flex-1 border border-[#dfdfdf] rounded-lg relative">
           <Input.TextArea
             ref={ref}
-            placeholder={i18n.chat_placeholder}
+            placeholder={
+              isExpanded
+                ? i18n.chat_expanded_placeholder
+                : i18n.chat_placeholder
+            }
             value={text}
             disabled={loading}
             autoFocus
@@ -94,14 +98,28 @@ const MessageInput: FC<{
             onCompositionStart={() => setIsInputComposition(true)}
             onCompositionEnd={() => setIsInputComposition(false)}
             onPressEnter={(e) => {
-              if (!e.shiftKey && !isInputComposition) {
-                e.preventDefault();
-                handleSubmit();
+              if (isInputComposition) {
+                return;
               }
+              if (isExpanded && !e.shiftKey) {
+                return;
+              }
+              if (!isExpanded && e.shiftKey) {
+                return;
+              }
+              e.preventDefault();
+              handleSubmit();
             }}
             size="large"
-            autoSize={{ minRows: 1, maxRows: 5 }}
-            allowClear
+            autoSize={isExpanded ? null : { minRows: 1, maxRows: 5 }}
+            rows={isExpanded ? 10 : null}
+            style={{ resize: 'none' }}
+          />
+          <i
+            className={`absolute right-0 translate-x-[-50%] top-0 translate-y-[-0%] z-50 cursor-pointer text-gradient text-[24px] ml-[0.5rem] ${
+              isExpanded ? 'ri-fullscreen-exit-fill' : 'ri-fullscreen-fill'
+            }`}
+            onClick={() => setIsExpanded(!isExpanded)}
           />
           {streamMessage && loading ? (
             <Button


### PR DESCRIPTION
To resolve https://github.com/GPTGenius/chatgpt-vercel/issues/49 and https://github.com/GPTGenius/chatgpt-vercel/issues/67

- add expand mode for input textarea to enhance the input efficiency
- change the prompt dropdown container so that it won't be overflow


<img width="400" alt="2023-06-04 23_28_35-ChatGPT" src="https://github.com/GPTGenius/chatgpt-vercel/assets/14119632/9e39bd36-a22f-426e-a728-c7d19d987a22">

<img width="400" alt="2023-06-04 23_28_58-ChatGPT" src="https://github.com/GPTGenius/chatgpt-vercel/assets/14119632/fb4584c6-b9e5-4786-bcaa-41fc30c1581a">
<img width="400" alt="2023-06-04 23_34_25-ChatGPT" src="https://github.com/GPTGenius/chatgpt-vercel/assets/14119632/1311365c-9ded-4958-9947-c4a146380448">
